### PR TITLE
Make `AU_SI_RESOLUTIONS` type a single literal type w/ two options

### DIFF
--- a/pm_tb_data/fetch/au_si.py
+++ b/pm_tb_data/fetch/au_si.py
@@ -13,7 +13,7 @@ from loguru import logger
 
 from pm_tb_data._types import Hemisphere
 
-AU_SI_RESOLUTIONS = Literal["25"] | Literal["12"]
+AU_SI_RESOLUTIONS = Literal["25", "12"]
 AU_SI_FN_REGEX = re.compile(
     r"AMSR_U2_L3_SeaIce12km_(?P<file_type>P|R)(?P<file_version>.*)_(?P<file_date>\d{8}).he5"
 )


### PR DESCRIPTION
This allows `typing.get_args` to return `("25", "12")`. This gets used in the `seaice_ecdr`. 