### PR TITLE
Support fetching NSIDC 0001 v6 from disk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.0
+
+* Add code to fetch NSIDC-0001 data from disk
+
+
 ## 0.2.0
 
 * Add code to download LANCE AMSR2 data to a local directory.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.3.0
 
-* Add code to fetch NSIDC-0001 data from disk
+* Add code to fetch NSIDC-0001 v6 data from disk.
 
 
 ## 0.2.0

--- a/pm_tb_data/fetch/au_si.py
+++ b/pm_tb_data/fetch/au_si.py
@@ -89,7 +89,6 @@ def _normalize_au_si_tbs(
 
 def get_au_si_tbs_from_disk(
     *,
-    date: dt.date,
     hemisphere: Hemisphere,
     resolution: AU_SI_RESOLUTIONS,
     data_filepath: Path,

--- a/pm_tb_data/fetch/au_si.py
+++ b/pm_tb_data/fetch/au_si.py
@@ -146,7 +146,6 @@ def get_au_si_tbs(
         )
 
     tb_data = get_au_si_tbs_from_disk(
-        date=date,
         hemisphere=hemisphere,
         resolution=resolution,
         data_filepath=data_filepath,

--- a/pm_tb_data/fetch/au_si.py
+++ b/pm_tb_data/fetch/au_si.py
@@ -39,7 +39,6 @@ def get_au_si_fp_on_disk(
 
 def _get_au_si_data_fields(
     *,
-    date: dt.date,
     hemisphere: Hemisphere,
     resolution: AU_SI_RESOLUTIONS,
     data_filepath: Path,
@@ -97,7 +96,6 @@ def get_au_si_tbs_from_disk(
 ) -> xr.Dataset:
     """Access AU_SI brightness temperatures from data files on local disk."""
     data_fields = _get_au_si_data_fields(
-        date=date,
         hemisphere=hemisphere,
         resolution=resolution,
         data_filepath=data_filepath,

--- a/pm_tb_data/fetch/lance_amsr2.py
+++ b/pm_tb_data/fetch/lance_amsr2.py
@@ -241,7 +241,6 @@ def access_local_lance_data(
     )
 
     data_fields = au_si.get_au_si_tbs_from_disk(
-        date=date,
         data_filepath=data_filepath,
         hemisphere=hemisphere,
         resolution=data_resolution,

--- a/pm_tb_data/fetch/nsidc_0001.py
+++ b/pm_tb_data/fetch/nsidc_0001.py
@@ -13,7 +13,7 @@ from typing import Literal
 
 import xarray as xr
 
-from pm_tb_data._types import NORTH, Hemisphere
+from pm_tb_data._types import Hemisphere
 
 NSIDC_0001_RESOLUTIONS = Literal["25", "12.5"]
 NSIDC_0001_SATS = Literal["F08", "F11", "F13", "F17", "F18"]
@@ -85,11 +85,3 @@ def get_nsidc_0001_tbs_from_disk(
     normalized_ds = _normalize_nsidc_0001_tbs(ds=ds, sat=sat)
 
     return normalized_ds
-
-
-if __name__ == "__main__":
-    data_dir = Path("/ecs/DP4/PM/NSIDC-0001.006/")
-    date = dt.date(2019, 1, 1)
-    tbs = get_nsidc_0001_tbs_from_disk(
-        date=date, hemisphere=NORTH, data_dir=data_dir, resolution="25", sat="F17"
-    )

--- a/pm_tb_data/fetch/nsidc_0001.py
+++ b/pm_tb_data/fetch/nsidc_0001.py
@@ -82,7 +82,7 @@ def get_nsidc_0001_tbs_from_disk(
         hemisphere=hemisphere,
     )
     ds = xr.open_dataset(filepath, group=sat)
-    normalized_ds = _normalize_nsidc_0001_tbs(ds=ds, date=date, sat=sat)
+    normalized_ds = _normalize_nsidc_0001_tbs(ds=ds, sat=sat)
 
     return normalized_ds
 

--- a/pm_tb_data/fetch/nsidc_0001.py
+++ b/pm_tb_data/fetch/nsidc_0001.py
@@ -26,10 +26,10 @@ def get_nsidc_0001_fp_on_disk(
     date: dt.date,
     resolution: NSIDC_0001_RESOLUTIONS,
 ) -> Path:
-    expected_fp = (
+    expected_fn = (
         f"NSIDC0001_TB_PS_{hemisphere[0].upper()}{resolution}km_{date:%Y%m%d}_v6.0.nc"
     )
-    expected_fp = data_dir / expected_fp
+    expected_fp = data_dir / expected_fn
 
     if not expected_fp.is_file():
         raise FileNotFoundError(

--- a/pm_tb_data/fetch/nsidc_0001.py
+++ b/pm_tb_data/fetch/nsidc_0001.py
@@ -1,0 +1,95 @@
+"""Code to access DMSP-series data (NSIDC-0001) from NSIDC.
+
+More information about NSIDC-0001: https://nsidc.org/data/nsidc-0001/versions/6
+
+NSIDC-0001 data are provided at two resolutions, depending on the channel:
+The 19.3 GHz, 22.2 GHz, and 37.0 GHz data are provided at a resolution of 25 km,
+and the 85.5 GHz and 91.7 GHz data are mapped to a 12.5 km grid.
+"""
+import datetime as dt
+import re
+from pathlib import Path
+from typing import Literal
+
+import xarray as xr
+
+from pm_tb_data._types import NORTH, Hemisphere
+
+NSIDC_0001_RESOLUTIONS = Literal["25", "12.5"]
+NSIDC_0001_SATS = Literal["F08", "F11", "F13", "F17", "F18"]
+
+
+def get_nsidc_0001_fp_on_disk(
+    *,
+    data_dir: Path,
+    hemisphere: Hemisphere,
+    date: dt.date,
+    resolution: NSIDC_0001_RESOLUTIONS,
+) -> Path:
+    expected_fp = (
+        f"NSIDC0001_TB_PS_{hemisphere[0].upper()}{resolution}km_{date:%Y%m%d}_v6.0.nc"
+    )
+    expected_fp = data_dir / expected_fp
+
+    if not expected_fp.is_file():
+        raise FileNotFoundError(
+            f"Expected to find 1 data file for NSIDC-0001 for {date:%Y-%m-%d}"
+            f" with filepath: {expected_fp}."
+        )
+
+    return expected_fp
+
+
+def _normalize_nsidc_0001_tbs(
+    *,
+    ds: xr.Dataset,
+    sat: NSIDC_0001_SATS,
+) -> xr.Dataset:
+    var_pattern = re.compile(f"TB_{sat}_" r"(?P<channel>\d{2})(?P<polarization>H|V)")
+
+    tb_data_mapping = {}
+    for var in ds.keys():
+        if match := var_pattern.match(str(var)):
+            tb_data_mapping[
+                f"{match.group('polarization').lower()}{match.group('channel')}"
+            ] = ds[var]
+
+    normalized = xr.Dataset(tb_data_mapping)
+
+    return normalized
+
+
+def get_nsidc_0001_tbs_from_disk(
+    *,
+    date: dt.date,
+    hemisphere: Hemisphere,
+    data_dir: Path,
+    resolution: NSIDC_0001_RESOLUTIONS,
+    sat: NSIDC_0001_SATS,
+) -> xr.Dataset:
+    """Return TB data from NSIDC-0001.
+
+    Note that the TBs returned are resolution-dependent:
+
+    The 19.3 GHz, 22.2 GHz, and 37.0 GHz data are provided at a resolution of 25 km,
+    and the 85.5 GHz and 91.7 GHz data are mapped to a 12.5 km grid.
+    """
+    expected_dir = data_dir / date.strftime("%Y.%m.%d")
+    filepath = get_nsidc_0001_fp_on_disk(
+        data_dir=expected_dir,
+        date=date,
+        resolution=resolution,
+        hemisphere=hemisphere,
+    )
+    ds = xr.open_dataset(filepath, group=sat)
+    normalized_ds = _normalize_nsidc_0001_tbs(ds=ds, date=date, sat=sat)
+
+    return normalized_ds
+
+
+if __name__ == "__main__":
+    data_dir = Path("/ecs/DP4/PM/NSIDC-0001.006/")
+    date = dt.date(2019, 1, 1)
+    tbs = get_nsidc_0001_tbs_from_disk(
+        date=date, hemisphere=NORTH, data_dir=data_dir, resolution="25", sat="F17"
+    )

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -23,6 +23,15 @@ def unit(ctx):
     )
 
 
+@task()
+def integration(ctx):
+    """Run unit tests."""
+    print_and_run(
+        f"pytest --cov=pm_tb_data -s {PROJECT_DIR}/tests/integration",
+        pty=True,
+    )
+
+
 @task(
     pre=[
         typecheck,

--- a/tests/integration/test_nsidc_0001.py
+++ b/tests/integration/test_nsidc_0001.py
@@ -1,0 +1,23 @@
+import datetime as dt
+from pathlib import Path
+
+from pm_tb_data._types import NORTH
+from pm_tb_data.fetch.nsidc_0001 import get_nsidc_0001_tbs_from_disk
+
+# Directory in which NSIDC-0001 V6 data is expected to be found.
+# NOTE/TODO: This path is specifc to NSIDC infrastructure. Make more generic?
+# Fetch data if not present?
+DATA_DIR = Path("/ecs/DP4/PM/NSIDC-0001.006/")
+
+
+def test_get_nsidc_0001_tbs_from_disk():
+    date = dt.date(2019, 1, 1)
+    tbs = get_nsidc_0001_tbs_from_disk(
+        date=date,
+        hemisphere=NORTH,
+        data_dir=DATA_DIR,
+        resolution="25",
+        sat="F17",
+    )
+
+    assert "h19" in tbs

--- a/tests/unit/test_nsidc_0001.py
+++ b/tests/unit/test_nsidc_0001.py
@@ -1,3 +1,6 @@
+import datetime as dt
+from pathlib import Path
+
 import numpy as np
 import xarray as xr
 from xarray.testing import assert_equal
@@ -27,3 +30,26 @@ def test__normalize_nsidc_0001_tbs():
     )
 
     assert_equal(actual, expected)
+
+
+def test_get_nsidc_0001_fp_on_disk(fs):
+    _data_dir = Path("/path/to/data/dir/2019.10.05")
+    _fake_files = [
+        _data_dir / "NSIDC0001_TB_PS_N25km_20191005_v6.0.nc",
+        _data_dir / "NSIDC0001_TB_PS_S25km_20191005_v6.0.nc",
+        _data_dir / "NSIDC0001_TB_PS_N12.5km_20191005_v6.0.nc",
+        _data_dir / "NSIDC0001_TB_PS_S12.5km_20191005_v6.0.nc",
+    ]
+    for _file in _fake_files:
+        fs.create_file(_file)
+
+    expected_file = _data_dir / "NSIDC0001_TB_PS_N25km_20191005_v6.0.nc"
+
+    actual = nsidc_0001.get_nsidc_0001_fp_on_disk(
+        data_dir=_data_dir,
+        date=dt.date(2019, 10, 5),
+        resolution="25",
+        hemisphere="north",
+    )
+
+    assert expected_file == actual

--- a/tests/unit/test_nsidc_0001.py
+++ b/tests/unit/test_nsidc_0001.py
@@ -1,0 +1,29 @@
+import numpy as np
+import xarray as xr
+from xarray.testing import assert_equal
+
+from pm_tb_data.fetch import nsidc_0001
+
+
+def test__normalize_nsidc_0001_tbs():
+    mock_nsidc_0001_ds = xr.Dataset(
+        data_vars={
+            "TB_F17_19H": ("x", np.arange(0, 5)),
+            "TB_F17_37V": ("x", np.arange(5, 10)),
+            "TB_F18_19H": ("x", np.arange(15, 20)),
+            "TB_F18_37V": ("x", np.arange(20, 25)),
+        },
+    )
+
+    expected = xr.Dataset(
+        data_vars={
+            "h19": ("x", np.arange(0, 5)),
+            "v37": ("x", np.arange(5, 10)),
+        },
+    )
+    actual = nsidc_0001._normalize_nsidc_0001_tbs(
+        ds=mock_nsidc_0001_ds,
+        sat="F17",
+    )
+
+    assert_equal(actual, expected)


### PR DESCRIPTION
Support fetching data NSIDC-0001 v6 data from a known location on-disk.

Currently assumes a standard directory structure & known `/ecs/` location on NSIDC infrastructure like the AU_SI data products do.