### PR TITLE
Init support for AE_SI12 and normalize dims across datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## 0.3.0
 
 * Add code to fetch NSIDC-0001 v6 data from disk.
+* Add code to fetch AE_SI12 v3 from disk.
+* `AU_SI`, `AE_SI`, and `NSIDC-0001` data normalization produces 'standard'
+  xarray dataset: variables are named in a consistent way, and variables all
+  have just two dims: `fake_x` and `fake_y`. Eventually the plan is to include
+  CRS information and projected coordinates instead.
 
 
 ## 0.2.0

--- a/pm_tb_data/fetch/ae_si.py
+++ b/pm_tb_data/fetch/ae_si.py
@@ -1,0 +1,45 @@
+"""Code to access AMSR-E data (AE_SI12) from NSIDC.
+
+* More information about AE_SI12: https://nsidc.org/data/ae_si12/versions/3
+"""
+import datetime as dt
+from pathlib import Path
+
+import xarray as xr
+
+from pm_tb_data._types import Hemisphere
+from pm_tb_data.fetch import au_si
+
+
+def get_ae_si_tbs_from_disk(
+    *,
+    date: dt.date,
+    hemisphere: Hemisphere,
+    data_dir: Path,
+    resolution: au_si.AU_SI_RESOLUTIONS,
+) -> xr.Dataset:
+    """Return TB data from AE_SI12."""
+    expected_dir = data_dir / date.strftime("%Y.%m.%d")
+    expected_fn = f"AMSR_E_L3_SeaIce{resolution}km_V15_{date:%Y%m%d}.hdf"
+    expected_fp = expected_dir / expected_fn
+
+    if not expected_fp.is_file():
+        raise FileNotFoundError(
+            f"Expected to find 1 data file for AE_SI{resolution} for {date:%Y-%m-%d}"
+            f" with filepath: {expected_fp}."
+        )
+
+    with xr.open_dataset(
+        expected_fp,
+        #  Specify the netcdf4 engine. The "h5netcdf" option does not seem to
+        #  work. Note that the netcdf4 engine results in a dataset that has all
+        #  of the variables (no subgroups)
+        engine="netcdf4",
+    ) as ds:
+        normalized = au_si._normalize_au_si_tbs(
+            data_fields=ds,
+            resolution=resolution,
+            hemisphere=hemisphere,
+        )
+
+    return normalized

--- a/pm_tb_data/fetch/ae_si.py
+++ b/pm_tb_data/fetch/ae_si.py
@@ -36,6 +36,11 @@ def get_ae_si_tbs_from_disk(
         #  of the variables (no subgroups)
         engine="netcdf4",
     ) as ds:
+        # TODO: extract normalize func to amsr util module? Make it more clear
+        # this is used generically for the AU/SI_* products. Need to be careful
+        # - not everything from the au_si module can be used for ae_si. E.g.,
+        # the data are stored differently and require a different invocation of
+        # `xr.open_dataset`
         normalized = au_si._normalize_au_si_tbs(
             data_fields=ds,
             resolution=resolution,

--- a/pm_tb_data/fetch/au_si.py
+++ b/pm_tb_data/fetch/au_si.py
@@ -83,7 +83,11 @@ def _normalize_au_si_tbs(
         if match := var_pattern.match(str(var)):
             tb_data_mapping[
                 f"{match.group('polarization').lower()}{match.group('channel')}"
-            ] = (("fake_y", "fake_x"), data_fields[var].data)
+            ] = xr.DataArray(
+                data_fields[var].data,
+                dims=("fake_y", "fake_x"),
+                attrs=data_fields[var].attrs,
+            )
 
     normalized = xr.Dataset(
         tb_data_mapping,

--- a/pm_tb_data/fetch/au_si.py
+++ b/pm_tb_data/fetch/au_si.py
@@ -55,6 +55,7 @@ def _get_au_si_data_fields(
             f"/{hemisphere[0].upper()}pPolarGrid{resolution}km"
             "/Data Fields"
         ),
+        engine="netcdf4",
     )
 
     return ds
@@ -63,6 +64,7 @@ def _get_au_si_data_fields(
 def _normalize_au_si_tbs(
     data_fields: xr.Dataset,
     resolution: AU_SI_RESOLUTIONS,
+    hemisphere: Hemisphere,
 ) -> xr.Dataset:
     """Normalize the given AU_SI* Tbs.
 
@@ -72,7 +74,8 @@ def _normalize_au_si_tbs(
     {channel}{polarization} name. E.g., `SI_25km_NH_06H_DAY` becomes `h06`
     """
     var_pattern = re.compile(
-        f"SI_{resolution}km_" r"(N|S)H_(?P<channel>\d{2})(?P<polarization>H|V)_DAY"
+        f"SI_{resolution}km_{hemisphere[0].upper()}H_"
+        r"(?P<channel>\d{2})(?P<polarization>H|V)_DAY"
     )
 
     tb_data_mapping = {}
@@ -80,9 +83,11 @@ def _normalize_au_si_tbs(
         if match := var_pattern.match(str(var)):
             tb_data_mapping[
                 f"{match.group('polarization').lower()}{match.group('channel')}"
-            ] = data_fields[var]
+            ] = (("fake_y", "fake_x"), data_fields[var].data)
 
-    normalized = xr.Dataset(tb_data_mapping)
+    normalized = xr.Dataset(
+        tb_data_mapping,
+    )
 
     return normalized
 
@@ -99,7 +104,9 @@ def get_au_si_tbs_from_disk(
         resolution=resolution,
         data_filepath=data_filepath,
     )
-    tb_data = _normalize_au_si_tbs(data_fields, resolution=resolution)
+    tb_data = _normalize_au_si_tbs(
+        data_fields, resolution=resolution, hemisphere=hemisphere
+    )
 
     return tb_data
 

--- a/pm_tb_data/fetch/au_si.py
+++ b/pm_tb_data/fetch/au_si.py
@@ -81,6 +81,8 @@ def _normalize_au_si_tbs(
     tb_data_mapping = {}
     for var in data_fields.keys():
         if match := var_pattern.match(str(var)):
+            # Preserve variable attrs, but rename the variable and it's dims for
+            # consistency.
             tb_data_mapping[
                 f"{match.group('polarization').lower()}{match.group('channel')}"
             ] = xr.DataArray(

--- a/pm_tb_data/fetch/nsidc_0001.py
+++ b/pm_tb_data/fetch/nsidc_0001.py
@@ -52,7 +52,7 @@ def _normalize_nsidc_0001_tbs(
         if match := var_pattern.match(str(var)):
             tb_data_mapping[
                 f"{match.group('polarization').lower()}{match.group('channel')}"
-            ] = ds[var]
+            ] = (("fake_y", "fake_x"), ds[var].isel(time=0).data)
 
     normalized = xr.Dataset(tb_data_mapping)
 

--- a/pm_tb_data/fetch/nsidc_0001.py
+++ b/pm_tb_data/fetch/nsidc_0001.py
@@ -50,9 +50,15 @@ def _normalize_nsidc_0001_tbs(
     tb_data_mapping = {}
     for var in ds.keys():
         if match := var_pattern.match(str(var)):
+            # Preserve variable attrs, but rename the variable and it's dims for
+            # consistency.
             tb_data_mapping[
                 f"{match.group('polarization').lower()}{match.group('channel')}"
-            ] = (("fake_y", "fake_x"), ds[var].isel(time=0).data)
+            ] = xr.DataArray(
+                ds[var].isel(time=0),
+                dims=("fake_y", "fake_x"),
+                attrs=ds[var].attrs,
+            )
 
     normalized = xr.Dataset(tb_data_mapping)
 

--- a/tests/integration/test_ae_si.py
+++ b/tests/integration/test_ae_si.py
@@ -1,0 +1,22 @@
+import datetime as dt
+from pathlib import Path
+
+from pm_tb_data._types import NORTH
+from pm_tb_data.fetch.ae_si import get_ae_si_tbs_from_disk
+
+# Directory in which AE_SI12 V3 data is expected to be found.
+# NOTE/TODO: This path is specifc to NSIDC infrastructure. Make more generic?
+# Fetch data if not present?
+DATA_DIR = Path("/ecs/DP4/AMSA/AE_SI12.003/")
+
+
+def test_get_ae_si_tbs_from_disk():
+    date = dt.date(2010, 1, 1)
+    tbs = get_ae_si_tbs_from_disk(
+        date=date,
+        hemisphere=NORTH,
+        data_dir=DATA_DIR,
+        resolution="12",
+    )
+
+    assert "h18" in tbs

--- a/tests/integration/test_au_si.py
+++ b/tests/integration/test_au_si.py
@@ -1,0 +1,21 @@
+import datetime as dt
+from pathlib import Path
+
+from pm_tb_data._types import NORTH
+from pm_tb_data.fetch.au_si import get_au_si_tbs
+
+# Directory in which AU_SI12 V3 data is expected to be found.
+# NOTE/TODO: This path is specifc to NSIDC infrastructure. Make more generic?
+# Fetch data if not present?
+DATA_DIR = Path("/ecs/DP1/AMSA/AU_SI12.001/")
+
+
+def test_get_au_si_tbs():
+    date = dt.date(2022, 3, 1)
+    tbs = get_au_si_tbs(
+        date=date,
+        hemisphere=NORTH,
+        resolution="12",
+    )
+
+    assert "h18" in tbs

--- a/tests/unit/test_au_si.py
+++ b/tests/unit/test_au_si.py
@@ -5,26 +5,28 @@ import numpy as np
 import xarray as xr
 from xarray.testing import assert_equal
 
+from pm_tb_data._types import NORTH
 from pm_tb_data.fetch import au_si
 
 
 def test__normalize_au_si_tbs():
     mock_au_si_data_fields = xr.Dataset(
         data_vars={
-            "SI_25km_NH_06H_DAY": ("x", np.arange(0, 5)),
-            "SI_25km_NH_89V_DAY": ("x", np.arange(5, 10)),
+            "SI_25km_NH_06H_DAY": (("Y", "X"), np.arange(0, 6).reshape(2, 3)),
+            "SI_25km_NH_89V_DAY": (("Y", "X"), np.arange(5, 11).reshape(2, 3)),
         },
     )
 
     expected = xr.Dataset(
         data_vars={
-            "h06": ("x", np.arange(0, 5)),
-            "v89": ("x", np.arange(5, 10)),
+            "h06": (("fake_y", "fake_x"), np.arange(0, 6).reshape(2, 3)),
+            "v89": (("fake_y", "fake_x"), np.arange(5, 11).reshape(2, 3)),
         },
     )
     actual = au_si._normalize_au_si_tbs(
         data_fields=mock_au_si_data_fields,
         resolution="25",
+        hemisphere=NORTH,
     )
 
     assert_equal(actual, expected)

--- a/tests/unit/test_nsidc_0001.py
+++ b/tests/unit/test_nsidc_0001.py
@@ -11,17 +11,17 @@ from pm_tb_data.fetch import nsidc_0001
 def test__normalize_nsidc_0001_tbs():
     mock_nsidc_0001_ds = xr.Dataset(
         data_vars={
-            "TB_F17_19H": ("x", np.arange(0, 5)),
-            "TB_F17_37V": ("x", np.arange(5, 10)),
-            "TB_F18_19H": ("x", np.arange(15, 20)),
-            "TB_F18_37V": ("x", np.arange(20, 25)),
+            "TB_F17_19H": (("time", "y", "x"), [np.arange(0, 6).reshape(2, 3)]),
+            "TB_F17_37V": (("time", "y", "x"), [np.arange(5, 11).reshape(2, 3)]),
+            "TB_F18_19H": (("time", "y", "x"), [np.arange(15, 21).reshape(2, 3)]),
+            "TB_F18_37V": (("time", "y", "x"), [np.arange(20, 26).reshape(2, 3)]),
         },
     )
 
     expected = xr.Dataset(
         data_vars={
-            "h19": ("x", np.arange(0, 5)),
-            "v37": ("x", np.arange(5, 10)),
+            "h19": (("fake_y", "fake_x"), np.arange(0, 6).reshape(2, 3)),
+            "v37": (("fake_y", "fake_x"), np.arange(5, 11).reshape(2, 3)),
         },
     )
     actual = nsidc_0001._normalize_nsidc_0001_tbs(


### PR DESCRIPTION
Adds support for fetching AE_SI12 data from a known location on disk. 

Also:

* Fixed issue with NSIDC-0001 having a `time` dimension. The other datasets we support do not have this `time` dimension, so remove it for consistency. We could re-visit this later, and maybe associate `time` with all datasets.
* Made dimension names consistent between AU_SI, AE_SI, and NSIDC-0001 normalized data. For now, these are `fake_x` and `fake_y`. These are grid dimensions, and the projected coordinates are not included with the returned data (yet, we'd like to).


Related PRs:

* https://github.com/nsidc/seaice_ecdr/pull/68
* https://github.com/nsidc/pm_icecon/pull/38